### PR TITLE
Update `cookbook()` method in `Widget::class` to accept an optional `$option` parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Change Log
 ## 0.1.4 March 28, 2024
 
 - Enh #37: Add `cookbook()` method to `Widget::class` (@terabytesoftw)
+- Bug #38: Update `cookbook()` method in `Widget::class` to accept an optional `$option` parameter (@terabytesoftw)
 
 ## 0.1.3 March 26, 2024
 

--- a/src/Base/Widget.php
+++ b/src/Base/Widget.php
@@ -43,7 +43,7 @@ abstract class Widget implements ElementInterface
      *
      * @return static The widget instance with the cookbook definitions applied.
      */
-    final public function cookbook(string $key, string $option): static
+    final public function cookbook(string $key, string $option = ''): static
     {
         /** @psalm-var array<string, mixed> $cookbook */
         $cookbook = $this->getCookbooks($option)[$key] ?? [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
